### PR TITLE
Better dependency injection and less global variables

### DIFF
--- a/src/database/index.js
+++ b/src/database/index.js
@@ -2,7 +2,7 @@ import debugLib from 'debug';
 import path from 'path';
 import knexManager from 'knex-db-manager';
 
-import { setDatabase, databaseInterface } from './interface'
+import { setDatabase } from './interface'
 
 const debug = debugLib(`${process.env.LOGGING_BASE}:database`);
 
@@ -43,16 +43,17 @@ export const databaseSetup = name => {
           //
           // returning a non-error here shows a warning in the console
           // (at least on node 10.16.3)
-          // ¯\_(ツ)_/¯
-          // we gotta do what we gotta do
+          // ¯\_(ツ)_/¯ we gotta do what we gotta do
           return dbManager.createDb();
         });
     })
     .then(() => dbManager.migrateDb())
     .then(() => {
       debug(`${process.env.DB_NAME} database migrated and ready to go`)
-      setDatabase(dbManager.knexInstance());
-      return { manager: dbManager, database: databaseInterface };
+      return {
+        manager: dbManager,
+        database: setDatabase(dbManager.knexInstance())
+      };
     })
     .catch(debug);
 };

--- a/src/database/interface/index.js
+++ b/src/database/interface/index.js
@@ -1,13 +1,9 @@
-import notes from './notes';
-
-let _database;
+import { notes } from './notes';
 
 export const setDatabase = database => {
-  _database = database;
-};
-
-export const database = () => {
-  return _database;
+  return {
+    notes: notes(database, crud)
+  }
 };
 
 export const scrub = resource => {
@@ -16,6 +12,12 @@ export const scrub = resource => {
   return resource;
 };
 
-export const databaseInterface = {
-  notes
+const crud = (db, implementation) => {
+  return {
+    create: resource => implementation.create(db, resource),
+    list: () => implementation.list(db),
+    get: id => implementation.get(db, id),
+    update: resource => implementation.update(db, resource),
+    remove: id => implementation.remove(db, id)
+  };
 };

--- a/src/database/interface/notes.js
+++ b/src/database/interface/notes.js
@@ -1,43 +1,47 @@
-import { database, scrub } from '.';
+import { scrub } from '.';
 
-const create = note => {
+const table = 'notes';
+
+const create = (db, note) => {
   return new Promise((resolve, reject) => {
-    return database()('notes').insert(note).returning('*')
+    return db(table).insert(note).returning('*')
       .then(([note]) => resolve(scrub(note)))
       .catch(reject);
   });
 };
 
-const list = () => {
+const list = db => {
   return new Promise((resolve, reject) => {
-    return database()('notes').whereNull('deleted_at').select('id', 'note')
+    return db(table).whereNull('deleted_at').select('id', 'note')
       .then(resolve)
       .catch(reject);
   });
 };
 
-const get = id => {
+const get = (db, id) => {
   return new Promise((resolve, reject) => {
-    return database()('notes').whereNull('deleted_at').where({ id }).select('*').first()
+    return db(table).whereNull('deleted_at').where({ id }).select('*').first()
       .then(note => resolve(scrub(note)))
       .catch(reject);
   });
 };
 
-const update = note => {
+const update = (db, note) => {
   return new Promise((resolve, reject) => {
-    return database()('notes').whereNull('deleted_at').where({ id: note.id }).update({ ...note, updated_at: database().fn.now() }).returning('*')
+    return db(table).whereNull('deleted_at').where({ id: note.id }).update({ ...note, updated_at: db.fn.now() }).returning('*')
       .then(([note]) => resolve(scrub(note)))
       .catch(reject);
   });
 };
 
-const remove = id => {
+const remove = (db, id) => {
   return new Promise((resolve, reject) => {
-    return database()('notes').whereNull('deleted_at').where({ id }).update({ deleted_at: database().fn.now() }).returning('id')
+    return db(table).whereNull('deleted_at').where({ id }).update({ deleted_at: db.fn.now() }).returning('id')
       .then(([id]) => resolve(id))
       .catch(reject);
   });
 };
 
-export default { create, list, get, update, remove };
+export const notes = (db, crud) => {
+  return crud(db, { create, list, get, update, remove })
+};


### PR DESCRIPTION
Got rid of "databaseIntegration" export
Made setDatabase return the actual implementation of that interface
No longer need to hold that global _database instance
DRY up some CRUD